### PR TITLE
Fixes app freeze on Init

### DIFF
--- a/NControl.Controls.iOS/NControls.cs
+++ b/NControl.Controls.iOS/NControls.cs
@@ -25,6 +25,7 @@ namespace NControl.Controls.iOS
 				s.Read (data, 0, data.Length);
 
 				var dataProvider = new CGDataProvider (data, 0, data.Length);
+				var familyNames = UIFont.FamilyNames; //fixes app freeze in some cases: https://alpha.app.net/jaredsinclair/post/18555292
 				var cgFont = CGFont.CreateFromProvider (dataProvider);
 				NSError error;
 


### PR DESCRIPTION
Per https://github.com/chrfalch/NControl.Controls/issues/17, referencing, https://alpha.app.net/jaredsinclair/post/18555292, this resolves
cases where the app would freeze on the call to
CGFont.CreateFromProvider.
