### PR TITLE
Added ButtonIconFontSize and ButtonIconFontSizeAuto to ActionButton, Fixed WizardPageXaml

### DIFF
--- a/NControl.Controls/NControl.Controls/ActionButton.cs
+++ b/NControl.Controls/NControl.Controls/ActionButton.cs
@@ -213,9 +213,9 @@ namespace NControl.Controls
 				});
 
 		/// <summary>
-		/// Gets or sets the color of the buton.
+		/// Gets or sets the button font family.
 		/// </summary>
-		/// <value>The color of the buton.</value>
+		/// <value>The button font family.</value>
 		public string ButtonFontFamily
 		{
 			get {  return (string)GetValue (ButtonFontFamilyProperty);}
@@ -249,9 +249,58 @@ namespace NControl.Controls
 		}
 
 		/// <summary>
-		/// The button icon property.
+		/// The button icon font size property.
 		/// </summary>
-		public static BindableProperty HasShadowProperty = 
+		public static BindableProperty ButtonIconFontSizeProperty =
+			BindableProperty.Create(nameof(ButtonIconFontSize), typeof(double), typeof(ActionButton), (double)14,
+				BindingMode.TwoWay, null, (bindable, oldValue, newValue) =>
+				{
+					var ctrl = (ActionButton)bindable;
+					ctrl.ButtonIconFontSize = (double)newValue;
+				});
+
+		/// <summary>
+		/// Gets or sets the size of the button icon font.
+		/// </summary>
+		/// <value>The size of the button icon font.</value>
+		public double ButtonIconFontSize
+		{
+			get { return (double)GetValue(ButtonIconFontSizeProperty); }
+			set
+			{
+				SetValue(ButtonIconFontSizeProperty, value);
+				ButtonIconLabel.FontSize = (double)value;
+			}
+		}
+
+		/// <summary>
+		/// The button icon font size auto property.
+		/// </summary>
+		public static BindableProperty ButtonIconFontSizeAutoProperty =
+			BindableProperty.Create(nameof(ButtonIconFontSizeAuto), typeof(bool), typeof(ActionButton), (bool)false,
+				BindingMode.TwoWay, null, (bindable, oldValue, newValue) =>
+				{
+					var ctrl = (ActionButton)bindable;
+					ctrl.ButtonIconFontSizeAuto = (bool)newValue;
+				});
+
+		/// <summary>
+		/// Gets or sets the automatic sizing of the button icon font size.
+		/// </summary>
+		/// <value>The size of the button icon auto font.</value>
+		public bool ButtonIconFontSizeAuto
+		{
+			get { return (bool)GetValue(ButtonIconFontSizeAutoProperty); }
+			set
+			{
+				SetValue(ButtonIconFontSizeAutoProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// The has shadow property.
+		/// </summary>
+		public static BindableProperty HasShadowProperty =
 			BindableProperty.Create(nameof(HasShadow), typeof(bool), typeof(ActionButton), true,
 				BindingMode.TwoWay, null, (bindable, oldValue, newValue) => {
 					var ctrl = (ActionButton)bindable;
@@ -391,7 +440,35 @@ namespace NControl.Controls
 
         #endregion
 
-        /// <summary>
+		/// <summary>
+		/// Lays out the children.
+		/// </summary>
+		/// <returns>The children.</returns>
+		/// <param name="x">The x coordinate.</param>
+		/// <param name="y">The y coordinate.</param>
+		/// <param name="width">Width.</param>
+		/// <param name="height">Height.</param>
+		protected override void LayoutChildren(double x, double y, double width, double height)
+		{
+			base.LayoutChildren(x, y, width, height);
+
+			if (ButtonIconFontSizeAuto)
+			{
+				//TODO: Improve the calculations for Auto FontSizing ratios
+				if (width > 0 && width < 32)
+					ButtonIconFontSize = width / 4;
+				if (width >= 32 && width < 64)
+					ButtonIconFontSize = width / 3.5;
+				if (width > 64 && width < 96)
+					ButtonIconFontSize = width / 3;
+				if (width >= 96 && width < 128)
+					ButtonIconFontSize = width / 2.5;
+				if (width >= 128)
+					ButtonIconFontSize = width / 2;
+			}
+		}
+
+		/// <summary>
         /// On Measure
         /// </summary>
         /// <param name="widthConstraint"></param>

--- a/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/ActionButtonPage.cs
+++ b/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/ActionButtonPage.cs
@@ -23,15 +23,17 @@ namespace NControl.Controls.Demo.FormsApp
 			var ab = new ActionButton {
 				ButtonColor = Color.FromHex("#E91E63"),
 				ButtonIcon = FontAwesomeLabel.FAThumbsUp,
+				ButtonIconFontSize = 18,
 			};
 			layout.Children.Add(ab, () => new Rectangle((layout.Width/4)-(56/2), (layout.Height/2)-(56/2), 56, 56));
 
 			var abtgl = new ToggleActionButton {
 				ButtonColor = Color.FromHex("#FF5722"),
 				ButtonIcon = FontAwesomeLabel.FAPlus,
+				ButtonIconFontSizeAuto = true,
 			};
 			abtgl.SetBinding (IsToggledProperty, "IsToggled");
-			layout.Children.Add(abtgl, () => new Rectangle((layout.Width/2)-(56/2), (layout.Height/2)-(56/2), 56, 56));
+			layout.Children.Add(abtgl, () => new Rectangle((layout.Width / 2) - (56 / 2), (layout.Height / 2) - (56 / 2), 84, 84));
 
 			_command = new Command ((obj) => {}, (obj) => abtgl.IsToggled);
 

--- a/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/WizardPage.cs
+++ b/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/WizardPage.cs
@@ -19,17 +19,17 @@ namespace NControl.Controls.Demo.FormsApp
 				Pages = {
 				new Button {
 					Command = new Command((obj)=>wizard.Page++),
+					Text = "Page 1",
+				},
+
+				new Button {
+					Command = new Command((obj)=>wizard.Page++),
 					Text = "Page 2",
 				},
 
 				new Button {
 					Command = new Command((obj)=>wizard.Page++),
 					Text = "Page 3",
-				},
-
-				new Button {
-					Command = new Command((obj)=>wizard.Page++),
-					Text = "Page 4",
 				},
 
 				new Button {

--- a/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/WizardPageXaml.xaml
+++ b/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/WizardPageXaml.xaml
@@ -1,14 +1,12 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentPage 
-		xmlns="http://xamarin.com/schemas/2014/forms" 
-		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
-		xmlns:ncontrols="clr-namespace:NControl.Controls;assembly=NControl.Controls"
-		x:Class="NControl.Controls.Demo.FormsApp.WizardPageXaml">
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:ncontrols="clr-namespace:NControl.Controls;assembly=NControl.Controls" x:Class="NControl.Controls.Demo.FormsApp.WizardPageXaml">
 	<ContentPage.Content>
-		<ncontrols:WizardLayout>
+		<ncontrols:WizardLayout x:Name="wizard">
 			<ncontrols:WizardLayout.Pages>
-				<ContentView><Label Text="Page 1"/></ContentView>
-				<ContentView><Label Text="Page 1"/></ContentView>
+				<ContentView><Button Text="Page 1" Clicked="Handle_Clicked" /></ContentView>
+				<ContentView><Button Text="Page 2" Clicked="Handle_Clicked" /></ContentView>
+				<ContentView><Button Text="Page 3" Clicked="Handle_Clicked" /></ContentView>
+				<ContentView><Button Text="Done" /></ContentView>
 			</ncontrols:WizardLayout.Pages>
 		</ncontrols:WizardLayout>
 	</ContentPage.Content>

--- a/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/WizardPageXaml.xaml.cs
+++ b/NControl.ControlsDemo/NControl.Controls.Demo.FormsApp/WizardPageXaml.xaml.cs
@@ -12,5 +12,10 @@ namespace NControl.Controls.Demo.FormsApp
 			InitializeComponent();
 			Title = "WizardLayout XAML";		
 		}
+
+		void Handle_Clicked(object sender, System.EventArgs e)
+		{
+			this.wizard.Page++;
+		}
 	}
 }


### PR DESCRIPTION
Added ButtonIconFontSize and ButtonIconFontSizeAuto to ActionButton to allow either autofont sizing or custom font sizing. I needed to be able to change the Font Awesome Icon size when buttons were larger than 56px.

The key parts (removed formatting changes from last PR):

ButtonIconFontSize
ButtonIconFontSizeAuto
override LayoutChildren

-----

Also Fixed WizardPageXaml

Let me know if you need further explanation.